### PR TITLE
Topic/vern/res 677

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -1,8 +1,5 @@
 module CVE_2022_30216_Detection;
 
-@load base/protocols/dce-rpc
-@load base/frameworks/notice
-
 export {
 	redef enum Notice::Type += {
 		ExploitAttempt,
@@ -10,28 +7,38 @@ export {
 	};
 }
 
-event dce_rpc_request_stub(c: connection, fid: count, ctx_id: count, opnum: count, stub: string)
+
+function report_exploit(c: connection, successful: bool, stub: string)
+	{
+	local status = successful ? "Successful" : "Attempted";
+	local exploit_modifier = successful ? "exploited" : "attempted exploit against";
+
+	local resp_h = c$id$resp_h;
+	local orig_h = c$id$orig_h;
+
+	local msg = fmt("%s CVE-2022-30216 exploit: %s %s %s",
+			status, orig_h, exploit_modifier, resp_h);
+
+	local clean_stub = find_last(gsub(stub, /\x00/, ""), /\\((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/);
+
+	if ( clean_stub != "" )
+		msg += " relaying to " + clean_stub[1:-1];
+
+	local n = successful ? ExploitSuccess : ExploitAttempt;
+	NOTICE([$note=n, $conn=c, $msg=msg, $identifier=cat(orig_h, resp_h)]);
+	}
+
+
+event dce_rpc_request_stub(c: connection, fid: count, ctx_id: count,
+				opnum: count, stub: string)
 	{
 	if ( opnum != 74 || ! c?$dce_rpc || ! c$dce_rpc?$endpoint )
 		return;
 
-	if ( c$dce_rpc$endpoint == "srvsvc" )
-		{
-		local resp_h = c$id$resp_h;
-		local orig_h = c$id$orig_h;
-		local clean_stub = find_last(gsub(stub, /\x00/, ""), /\\((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/);
-		if ( clean_stub != "" )
-			NOTICE([$note=ExploitAttempt, $conn=c, 
-				$msg=fmt("Attempted CVE-2022-30216 exploit: %s attempted exploit against %s relaying to %s", 
-					orig_h, resp_h, clean_stub[1:-1]),
-				$identifier=cat(orig_h, resp_h)]);
-		else
-			NOTICE([$note=ExploitAttempt, $conn=c, 
-				$msg=fmt("Attempted CVE-2022-30216 exploit: %s attempted exploit against %s", 
-					orig_h, resp_h),
-				$identifier=cat(orig_h, resp_h)]);
-		}
+	if ( c$dce_rpc$endpoint != "srvsvc" )
+		return;
 
+	report_exploit(c, F, stub);
 	}
 
 event dce_rpc_response_stub(c: connection, fid: count, ctx_id: count, opnum: count, stub: string)
@@ -39,33 +46,19 @@ event dce_rpc_response_stub(c: connection, fid: count, ctx_id: count, opnum: cou
 	if ( opnum != 74 || ! c?$dce_rpc_backing )
 		return;
 
-	local contains_srvsvc = F;
-	for ( backing in c$dce_rpc_backing )
+	local dr_backing = c$dce_rpc_backing;
+
+	for ( backing in dr_backing )
 		{
-		local b = c$dce_rpc_backing[backing];
-		if ( b?$info && b$info?$endpoint && b$info$endpoint == "srvsvc" )
+		local b = dr_backing[backing];
+
+		if ( ! b?$info || ! b$info?$endpoint )
+			next;
+
+		if ( b$info$endpoint == "srvsvc" )
 			{
-			contains_srvsvc = T;
-			break;
+			report_exploit(c, T, stub);
+			return;
 			}
 		}
-	
-	if ( ! contains_srvsvc )
-		return;
-
-	local resp_h = c$id$resp_h;
-	local orig_h = c$id$orig_h;
-	local clean_stub = find_last(gsub(stub, /\x00/, ""), /\\((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/);
-	
-	if ( clean_stub != "" )
-		NOTICE([$note=ExploitSuccess, $conn=c, 
-			$msg=fmt("Successful CVE-2022-30216 exploit: %s exploited %s relaying to %s", 
-					orig_h, resp_h, clean_stub[1:-1]),
-			$identifier=cat(orig_h, resp_h)]);
-	else
-		NOTICE([$note=ExploitSuccess, $conn=c, 
-			$msg=fmt("Successful CVE-2022-30216 exploit: %s exploited %s", 
-					orig_h, resp_h),
-			$identifier=cat(orig_h, resp_h)]);
-
 	}

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -42,7 +42,8 @@ event dce_rpc_response_stub(c: connection, fid: count, ctx_id: count, opnum: cou
 	local contains_srvsvc = F;
 	for ( backing in c$dce_rpc_backing )
 		{
-		if ( c$dce_rpc_backing[backing]$info$endpoint == "srvsvc" )
+		local b = c$dce_rpc_backing[backing];
+		if ( b?$info && b$info?$endpoint && b$info$endpoint == "srvsvc" )
 			{
 			contains_srvsvc = T;
 			break;


### PR DESCRIPTION
This PR addresses fixes warnings due to accesses to an undefined record field.  It also tidies up the code by removing some unneeded `@load`s and factoring out commonality in generating Notices.